### PR TITLE
refactor(ui-builder): re-use shared UI types from @adapty/core

### DIFF
--- a/examples/adapty-devtools/yarn.lock
+++ b/examples/adapty-devtools/yarn.lock
@@ -6,10 +6,10 @@
   version "0.0.0"
   uid ""
 
-"@adapty/core@3.17.0-dev.2cd14ddac1a5989c081883c6f0cac85780d14d4d":
-  version "3.17.0-dev.2cd14ddac1a5989c081883c6f0cac85780d14d4d"
-  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-3.17.0-dev.2cd14ddac1a5989c081883c6f0cac85780d14d4d.tgz#f6cdee3bf69dde5d69354229a6e62323e417a563"
-  integrity sha512-TihxXNboLJ1dgr+xZSbofqHFUgzq9DlCCGmXF3L5MOhEUHyH3Jw1uA8vg6bySLRH5VFVeCEnQa/YL5hUXx1Oww==
+"@adapty/core@4.0.0-dev.be3bfb2d97c35a578f09706e179187ebdb312943":
+  version "4.0.0-dev.be3bfb2d97c35a578f09706e179187ebdb312943"
+  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-4.0.0-dev.be3bfb2d97c35a578f09706e179187ebdb312943.tgz#052151e67c9cbee48fb8755e52f8e60099a61b35"
+  integrity sha512-p/yZN2gInlMRUZFr7yuRI/cyjv7rSTf1um2AmoKIwrpyhdLXBL6V9PuJDKuakDbnqodDjPqMg180CKVwju8b+A==
   dependencies:
     tslib "^2.5.0"
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@capacitor/core": ">=8.0.0"
   },
   "dependencies": {
-    "@adapty/core": "3.17.0-dev.2cd14ddac1a5989c081883c6f0cac85780d14d4d",
+    "@adapty/core": "4.0.0-dev.be3bfb2d97c35a578f09706e179187ebdb312943",
     "tslib": "^2.5.0"
   },
   "publishConfig": {

--- a/src/ui-builder/types.ts
+++ b/src/ui-builder/types.ts
@@ -1,225 +1,38 @@
-import type { AdaptyError } from '@adapty/core';
+import type { AdaptyPurchaseResult, EventHandlers, OnboardingEventHandlers, WebPresentation } from '@adapty/core';
 
 import { Log } from '../logger';
-import type {
-  AdaptyPaywallProduct,
-  AdaptyProductIdentifier,
-  AdaptyProfile,
-  AdaptyPurchaseResult,
-  WebPresentation,
-} from '../types';
-import type { FileLocation, MakePurchaseParamsInput } from '../types/inputs';
+
+// Re-export all shared UI types from @adapty/core
+export type {
+  EventHandlerResult,
+  ProductPurchaseParams,
+  EventHandlers,
+  OnboardingEventHandlers,
+  OnboardingAnalyticsEventName,
+  AdaptyUiOnboardingMeta,
+  AdaptyUiOnboardingStateParams,
+  OnboardingStateUpdatedAction,
+  CreatePaywallViewParamsInput,
+  CreateOnboardingViewParamsInput,
+  AdaptyUiView,
+  AdaptyUiMediaCache,
+  AdaptyUiDialogConfig,
+  AdaptyCustomAsset,
+  AdaptyCustomImageAsset,
+  AdaptyCustomVideoAsset,
+  AdaptyCustomColorAsset,
+  AdaptyCustomGradientAsset,
+  AdaptyIOSPresentationStyle,
+} from '@adapty/core';
+
+export { AdaptyUiDialogActionType } from '@adapty/core';
 
 /**
- * @internal
- */
-export type ArgType<T> = T extends () => any ? void : T extends (arg: infer U) => any ? U : void;
-
-/**
- * EventHandler callback should not return a promise,
- * because using `await` may postpone closing a paywall view.
+ * Default event handlers that provide standard closing behavior.
  *
- * We don't want to block the UI thread.
- */
-export type EventHandlerResult = boolean | void;
-
-/**
- * Purchase parameters keyed by AdaptyProductIdentifier objects
- */
-export type ProductPurchaseParams = {
-  productId: AdaptyProductIdentifier;
-  params: MakePurchaseParamsInput;
-}[];
-
-export type AdaptyCustomAsset =
-  | AdaptyCustomImageAsset
-  | AdaptyCustomVideoAsset
-  | AdaptyCustomColorAsset
-  | AdaptyCustomGradientAsset;
-
-export type AdaptyCustomImageAsset =
-  | { type: 'image'; base64: string }
-  | { type: 'image'; relativeAssetPath: string } // shorthand: uses same path for both iOS fileName and Android relativeAssetPath
-  | { type: 'image'; fileLocation: FileLocation }; // full control for platform-specific paths
-
-export type AdaptyCustomVideoAsset =
-  | { type: 'video'; relativeAssetPath: string } // shorthand: uses same path for both iOS fileName and Android relativeAssetPath
-  | { type: 'video'; fileLocation: FileLocation }; // full control for platform-specific paths
-
-export type AdaptyCustomColorAsset =
-  | { type: 'color'; argb: number /* e.g. 0xFFFF0000 (opaque red) */ }
-  | { type: 'color'; rgb: number /* e.g. 0xFF0000 (red) */ }
-  | { type: 'color'; rgba: number /* e.g. 0xFF0000FF (opaque red) */ };
-
-export type AdaptyCustomGradientAsset = {
-  type: 'linear-gradient';
-  values: ({ p: number; argb: number } | { p: number; rgb: number } | { p: number; rgba: number })[];
-  points?: { x0?: number; y0?: number; x1?: number; y1?: number };
-};
-
-export type AdaptyUiOnboardingMeta = {
-  onboardingId: string;
-  screenClientId: string;
-  screenIndex: number;
-  totalScreens: number;
-};
-
-export type AdaptyUiOnboardingStateParams = {
-  id: string;
-  value: string;
-  label: string;
-};
-
-/**
- * Paywall event handlers configuration
- *
- * @see {@link https://adapty.io/docs/capacitor-handling-events | [DOC] Handling View Events}
- */
-export interface EventHandlers {
-  /**
-   * Called when a user taps the close button on the paywall view
-   *
-   * If you return `true`, the paywall view will be closed.
-   * We strongly recommend to return `true` in this case.
-   * @default true
-   */
-  onCloseButtonPress: () => EventHandlerResult;
-  /**
-   * Called when a user navigates back on Android
-   *
-   * If you return `true`, the paywall view will be closed.
-   * We strongly recommend to return `true` in this case.
-   * @default true
-   */
-  onAndroidSystemBack: () => EventHandlerResult;
-  /**
-   * Called when a user taps an URL in the paywall view.
-   *
-   * If you return `true`, the paywall view will be closed.
-   * @default false
-   *
-   * The default onUrlPress handler does not support `browser_in_app`.
-   * To support it, install an in-app browser plugin (e.g. `@capacitor/inappbrowser`)
-   * and handle the `openIn` argument in your own custom onUrlPress handler.
-   *
-   * @param url - URL to open
-   * @param openIn - How the URL was configured to open in the dashboard:
-   *                 `'browser_in_app'` — in-app browser
-   *                 `'browser_out_app'` — external/system browser
-   */
-  onUrlPress: (url: string, openIn: WebPresentation) => EventHandlerResult;
-  /**
-   * Called when a user performs a custom action in the paywall view
-   *
-   * If you return `true`, the paywall view will be closed.
-   * @default false
-   */
-  onCustomAction: (actionId: string) => EventHandlerResult;
-  /**
-   * Called when a user selects a product in the paywall view
-   *
-   * If you return `true` from this callback, the paywall view will be closed.
-   * @default false
-   */
-  onProductSelected: (productId: string) => EventHandlerResult;
-  /**
-   * Called when a purchase process starts
-   *
-   * If you return `true` from this callback, the paywall view will be closed.
-   * @default false
-   */
-  onPurchaseStarted: (product: AdaptyPaywallProduct) => EventHandlerResult;
-  /**
-   * Called when the purchase succeeds, the user cancels their purchase, or the purchase appears to be pending
-   *
-   * If you return `true` from this callback, the paywall view will be closed.
-   * We strongly recommend returning `purchaseResult.type !== 'user_cancelled'` in this case.
-   * @default `purchaseResult.type !== 'user_cancelled'`
-   *
-   * @param purchaseResult - object, which provides details about the purchase.
-   * If the result is `'success'`, it also includes the updated user's profile.
-   */
-  onPurchaseCompleted: (purchaseResult: AdaptyPurchaseResult, product: AdaptyPaywallProduct) => EventHandlerResult;
-  /**
-   * Called if a purchase fails after a user taps the purchase button
-   *
-   * If you return `true` from this callback, the paywall view will be closed.
-   * @default false
-   *
-   * @param error - AdaptyError object with error code and message
-   */
-  onPurchaseFailed: (error: AdaptyError, product: AdaptyPaywallProduct) => EventHandlerResult;
-  /**
-   * Called when a user taps the restore button in the paywall view
-   *
-   * If you return `true` from this callback, the paywall view will be closed.
-   * @default false
-   */
-  onRestoreStarted: () => EventHandlerResult;
-  /**
-   * Called when a purchase is completed
-   *
-   * If you return `true` from this callback, the paywall view will be closed.
-   * We strongly recommend to return `true` in this case.
-   * @default true
-   *
-   * @param profile - updated user profile
-   */
-  onRestoreCompleted: (profile: AdaptyProfile) => EventHandlerResult;
-  /**
-   * Called if a restore fails after a user taps the restore button
-   *
-   * If you return `true` from this callback, the paywall view will be closed.
-   * @default false
-   *
-   * @param error - AdaptyError object with error code and message
-   */
-  onRestoreFailed: (error: AdaptyError) => EventHandlerResult;
-  /**
-   * Called when the paywall view appears
-   *
-   * If you return `true`, the paywall view will be closed.
-   * @default false
-   */
-  onAppeared: () => EventHandlerResult;
-  /**
-   * Called when the paywall view disappears
-   *
-   * If you return `true`, the paywall view will be closed.
-   * @default false
-   */
-  onDisappeared: () => EventHandlerResult;
-  /**
-   * Called if a paywall view fails to render.
-   * This should not ever happen, but if it does, feel free to report it to us.
-   *
-   * If you return `true` from this callback, the paywall view will be closed.
-   * @default true
-   *
-   * @param error - AdaptyError object with error code and message
-   */
-  onRenderingFailed: (error: AdaptyError) => EventHandlerResult;
-  /**
-   * Called if a product list fails to load on a presented view,
-   * for example, if there is no internet connection
-   *
-   * If you return `true` from this callback, the paywall view will be closed.
-   * @default false
-   *
-   * @param error - AdaptyError object with error code and message
-   */
-  onLoadingProductsFailed: (error: AdaptyError) => EventHandlerResult;
-  /**
-   * Called when web payment navigation finishes
-   *
-   * If you return `true`, the paywall view will be closed.
-   * @default false
-   */
-  onWebPaymentNavigationFinished: (product?: AdaptyPaywallProduct, error?: AdaptyError) => EventHandlerResult;
-}
-
-/**
- * Default event handlers that provide standard closing behavior
+ * The default onUrlPress handler does not support `browser_in_app`.
+ * To support it, install an in-app browser plugin (e.g. `@capacitor/inappbrowser`)
+ * and handle the `openIn` argument in your own custom onUrlPress handler.
  */
 export const DEFAULT_EVENT_HANDLERS: EventHandlers = {
   onCloseButtonPress: () => true,
@@ -256,149 +69,6 @@ export const DEFAULT_EVENT_HANDLERS: EventHandlers = {
   onWebPaymentNavigationFinished: () => false,
 };
 
-export type OnboardingStateUpdatedAction =
-  | {
-      elementId: string;
-      elementType: 'select';
-      value: AdaptyUiOnboardingStateParams;
-    }
-  | {
-      elementId: string;
-      elementType: 'multi_select';
-      value: AdaptyUiOnboardingStateParams[];
-    }
-  | {
-      elementId: string;
-      elementType: 'input';
-      value: { type: 'text' | 'email'; value: string } | { type: 'number'; value: number };
-    }
-  | {
-      elementId: string;
-      elementType: 'date_picker';
-      value: {
-        day?: number;
-        month?: number;
-        year?: number;
-      };
-    };
-
-export interface AdaptyUiView {
-  id: string;
-}
-
-export interface AdaptyUiMediaCache {
-  memoryStorageTotalCostLimit?: number;
-  memoryStorageCountLimit?: number;
-  diskStorageSizeLimit?: number;
-}
-
-export interface AdaptyUiDialogConfig {
-  /**
-   * The action title to display as part of the dialog. If you provide two actions,
-   * be sure `primaryAction` cancels the operation and leaves things unchanged.
-   */
-  primaryActionTitle: string;
-  /**
-   * The secondary action title to display as part of the dialog.
-   */
-  secondaryActionTitle?: string;
-  /**
-   * The title of the dialog.
-   */
-  title?: string;
-  /**
-   * Descriptive text that provides additional details about the reason for the dialog.
-   */
-  content?: string;
-}
-
-export const AdaptyUiDialogActionType = Object.freeze({
-  primary: 'primary',
-  secondary: 'secondary',
-});
-
-export type AdaptyUiDialogActionType = (typeof AdaptyUiDialogActionType)[keyof typeof AdaptyUiDialogActionType];
-
-/**
- * Additional options for creating a paywall view
- *
- * @see {@link https://adapty.io/docs/capacitor-present-paywalls | [DOC] Creating Paywall View}
- */
-export interface CreatePaywallViewParamsInput {
-  /**
-   * `true` if you want to prefetch products before presenting a paywall view.
-   */
-  prefetchProducts?: boolean;
-  /**
-   * This value limits the timeout (in milliseconds) for this method.
-   */
-  loadTimeoutMs?: number;
-  /**
-   * If you are going to use custom tags functionality, pass an object with tags and corresponding replacement values
-   *
-   * ```
-   * {
-   *   'USERNAME': 'Bruce',
-   *   'CITY': 'Philadelphia'
-   * }
-   * ```
-   */
-  customTags?: Record<string, string>;
-  /**
-   * If you are going to use custom timer functionality, pass an object with timer ids and corresponding dates the timers should end at
-   */
-  customTimers?: Record<string, Date>;
-  /**
-   * Use this when you need to override paywall assets with your own
-   */
-  customAssets?: Record<string, AdaptyCustomAsset>;
-  /**
-   * Provide per-product purchase parameters keyed by Adapty product identifier
-   */
-  productPurchaseParams?: ProductPurchaseParams;
-}
-
-/**
- * Additional options for creating an onboarding view
- *
- * @see {@link https://adapty.io/docs/capacitor-get-onboardings | [DOC] Creating Onboarding View}
- */
-export interface CreateOnboardingViewParamsInput {
-  /**
-   * If you want to change the presentation behavior of external URLs, pass a preferred value.
-   *
-   * @default {@link WebPresentation.BrowserInApp}
-   */
-  externalUrlsPresentation?: WebPresentation;
-}
-
-export interface OnboardingEventHandlers {
-  onClose: (actionId: string, meta: AdaptyUiOnboardingMeta) => EventHandlerResult;
-  onCustom: (actionId: string, meta: AdaptyUiOnboardingMeta) => EventHandlerResult;
-  onPaywall: (actionId: string, meta: AdaptyUiOnboardingMeta) => EventHandlerResult;
-  onStateUpdated: (action: OnboardingStateUpdatedAction, meta: AdaptyUiOnboardingMeta) => EventHandlerResult;
-  onFinishedLoading: (meta: AdaptyUiOnboardingMeta) => EventHandlerResult;
-  onAnalytics: (
-    event: {
-      name: string;
-      /**
-       * @deprecated Use `elementId` instead
-       */
-      element_id?: string;
-      elementId?: string;
-      reply?: string;
-    },
-    meta: AdaptyUiOnboardingMeta,
-  ) => EventHandlerResult;
-  onError: (error: AdaptyError) => EventHandlerResult;
-}
-
 export const DEFAULT_ONBOARDING_EVENT_HANDLERS: Partial<OnboardingEventHandlers> = {
   onClose: () => true,
 };
-
-/**
- * iOS presentation style for paywall and onboarding views
- * @platform ios
- */
-export type AdaptyIOSPresentationStyle = 'full_screen' | 'page_sheet';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adapty/core@3.17.0-dev.2cd14ddac1a5989c081883c6f0cac85780d14d4d":
-  version "3.17.0-dev.2cd14ddac1a5989c081883c6f0cac85780d14d4d"
-  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-3.17.0-dev.2cd14ddac1a5989c081883c6f0cac85780d14d4d.tgz#f6cdee3bf69dde5d69354229a6e62323e417a563"
-  integrity sha512-TihxXNboLJ1dgr+xZSbofqHFUgzq9DlCCGmXF3L5MOhEUHyH3Jw1uA8vg6bySLRH5VFVeCEnQa/YL5hUXx1Oww==
+"@adapty/core@4.0.0-dev.be3bfb2d97c35a578f09706e179187ebdb312943":
+  version "4.0.0-dev.be3bfb2d97c35a578f09706e179187ebdb312943"
+  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-4.0.0-dev.be3bfb2d97c35a578f09706e179187ebdb312943.tgz#052151e67c9cbee48fb8755e52f8e60099a61b35"
+  integrity sha512-p/yZN2gInlMRUZFr7yuRI/cyjv7rSTf1um2AmoKIwrpyhdLXBL6V9PuJDKuakDbnqodDjPqMg180CKVwju8b+A==
   dependencies:
     tslib "^2.5.0"
 


### PR DESCRIPTION
Removed duplicated types from src/ui-builder/types.ts (EventHandlers, OnboardingEventHandlers, AdaptyCustomAsset and its variants, AdaptyUiDialogConfig, CreateXxxParamsInput, AdaptyUiView, AdaptyUiMediaCache, AdaptyIOSPresentationStyle,
OnboardingStateUpdatedAction, etc.) — they are now re-exported from @adapty/core.

Only Capacitor-specific artifacts remain local:
- DEFAULT_EVENT_HANDLERS (uses window.open + Log.warn)
- DEFAULT_ONBOARDING_EVENT_HANDLERS

Dead code ArgType has been removed.