### PR TITLE
feat!: expose AdaptyExternalAttributionProvider from core

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@capacitor/core": ">=8.0.0"
   },
   "dependencies": {
-    "@adapty/core": "4.1.0-dev.51f7b5e66af39a9a82a499d0a75bedc5b5c796f5",
+    "@adapty/core": "4.1.0-dev.1396a8d7cefb0e3107a7ddc23796d2d092e89ec2",
     "tslib": "^2.5.0"
   },
   "publishConfig": {

--- a/src/__tests__/integration/adapty-handler/profile.test.ts
+++ b/src/__tests__/integration/adapty-handler/profile.test.ts
@@ -106,8 +106,8 @@ describe('Adapty - Profile', () => {
         referral_code: 'FRIEND2024',
       });
 
-      // appliedAttributionSources decoded from native applied_attribution_sources
-      expect(profile.appliedAttributionSources).toEqual(['apple_search_ads']);
+      // appliedExternalAttributionProviders decoded from native applied_attribution_sources
+      expect(profile.appliedExternalAttributionProviders).toEqual(['apple_search_ads']);
     });
   });
 

--- a/src/__tests__/types-exports.test.ts
+++ b/src/__tests__/types-exports.test.ts
@@ -5,6 +5,7 @@
  * exists so Jest has something to run.
  */
 import type {
+  AdaptyExternalAttributionProvider,
   AdaptyFlow,
   AdaptyFlowUiSchema,
   AdaptyFlowUiSchemaGrid,
@@ -21,6 +22,14 @@ describe('public type exports', () => {
     };
 
     expect(product.vendorProductId).toBe('yearly.premium.6999');
+  });
+
+  it('exposes AdaptyExternalAttributionProvider, including unlisted providers', () => {
+    const known: AdaptyExternalAttributionProvider = 'appsflyer';
+    // The backend may add providers without an SDK release, so any string stays valid.
+    const unknown: AdaptyExternalAttributionProvider = 'some_future_provider';
+
+    expect([known, unknown]).toStrictEqual(['appsflyer', 'some_future_provider']);
   });
 
   it('exposes the flow ui schema types', () => {

--- a/src/adapty.ts
+++ b/src/adapty.ts
@@ -10,6 +10,7 @@ import { defaultAdaptyOptions } from './default-configs';
 import { Log, LogContext } from './logger';
 import type { LoggerConfig, LogScope } from './logger';
 import type {
+  AdaptyExternalAttributionProvider,
   AdaptyFlow,
   AdaptyFlowPaywall,
   AdaptyPaywallProduct,
@@ -1393,6 +1394,7 @@ export class Adapty implements AdaptyPlugin {
    * @param options - The options object
    * @param options.attribution - An object containing attribution data.
    * @param options.provider - The attribution provider the data came from (e.g., 'adjust', 'appsflyer').
+   *   Any string is accepted, so a provider added by the backend works without an SDK update.
    * @returns A promise that resolves when the attribution data is updated.
    * @throws Error if parameters are invalid or not provided.
    *
@@ -1414,7 +1416,10 @@ export class Adapty implements AdaptyPlugin {
    * }
    * ```
    */
-  async updateExternalAttribution(options: { attribution: Record<string, any>; provider: string }): Promise<void> {
+  async updateExternalAttribution(options: {
+    attribution: Record<string, any>;
+    provider: AdaptyExternalAttributionProvider;
+  }): Promise<void> {
     const method = 'update_external_attribution_data';
 
     const ctx = new LogContext();

--- a/src/types/adapty-plugin.ts
+++ b/src/types/adapty-plugin.ts
@@ -4,6 +4,7 @@ import type { PluginListenerHandle } from '@capacitor/core';
 import type { LoggerConfig } from '../logger';
 
 import type {
+  AdaptyExternalAttributionProvider,
   AdaptyFlow,
   AdaptyFlowPaywall,
   AdaptyPaywallProduct,
@@ -163,7 +164,10 @@ export interface AdaptyPlugin {
   /**
    * Updates attribution data from an external attribution provider for the current user.
    */
-  updateExternalAttribution(options: { attribution: Record<string, any>; provider: string }): Promise<void>;
+  updateExternalAttribution(options: {
+    attribution: Record<string, any>;
+    provider: AdaptyExternalAttributionProvider;
+  }): Promise<void>;
 
   /**
    * Updates collecting refund data consent (iOS only).

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,7 @@ export type {
   AdaptyOnboardingBuilder,
   AdaptyPurchaseResult,
   AdaptyProfile,
-  AttributionSource,
+  AdaptyExternalAttributionProvider,
   AdaptyAccessLevel,
   AdaptyNonSubscription,
   AdaptySubscription,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adapty/core@4.1.0-dev.51f7b5e66af39a9a82a499d0a75bedc5b5c796f5":
-  version "4.1.0-dev.51f7b5e66af39a9a82a499d0a75bedc5b5c796f5"
-  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-4.1.0-dev.51f7b5e66af39a9a82a499d0a75bedc5b5c796f5.tgz#63a8884ba64d5f0326d1f307936d5f1bcb2037d8"
-  integrity sha512-4pf9UR83tfakyMR/y3VeFSPmS7mkCjSKdljSX0xTA892r9LxzTNT7QUBRV+YUP6X76bYSFhtKv+JdnDsDW1X2Q==
+"@adapty/core@4.1.0-dev.1396a8d7cefb0e3107a7ddc23796d2d092e89ec2":
+  version "4.1.0-dev.1396a8d7cefb0e3107a7ddc23796d2d092e89ec2"
+  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-4.1.0-dev.1396a8d7cefb0e3107a7ddc23796d2d092e89ec2.tgz#4c4e2af84bd3e09d07d49450898f59103a8d4aef"
+  integrity sha512-CsgEv98H1sb3M3cpforVo2jjJ+WFMr9+wfZm+ZIrTCiu/4gfVVMSEWhAL8+vE1sZFVpTdMqyJj2KjNhe61+f7Q==
   dependencies:
     tslib "^2.5.0"
 


### PR DESCRIPTION
the public type export becomes AdaptyExternalAttributionProvider, updateExternalAttribution takes it instead of a bare string, and the profile now reads appliedExternalAttributionProviders off the unchanged applied_attribution_sources key.